### PR TITLE
[FIXES #76]: Integrate Auth0 for Token Generation and User Authentica…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "tessera-ui",
       "dependencies": {
+        "@auth0/auth0-react": "^2.16.2",
         "axios": "^1.10.0",
         "cmdk": "^1.1.1",
         "radix-ui": "^1.4.3",
@@ -74,6 +75,12 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
+
+    "@auth0/auth0-auth-js": ["@auth0/auth0-auth-js@1.6.0", "", { "dependencies": { "jose": "^6.0.8", "openid-client": "^6.8.0" } }, "sha512-/WYYNlsqhWA6I60pMVLFVeOgjOUCLdJThEAsjN8pAgYY09BTxbPaRIEVDgGu6ckoJpkmKvEYlHPO/vwRNrvX6w=="],
+
+    "@auth0/auth0-react": ["@auth0/auth0-react@2.16.2", "", { "dependencies": { "@auth0/auth0-spa-js": "^2.19.2" }, "peerDependencies": { "react": "^16.11.0 || ^17 || ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1", "react-dom": "^16.11.0 || ^17 || ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-Sp7aXuvSMXh0qO74wv25ZsNjCAX1HItU2LhHCvPAJKQYRr/Rc9b1OtdyhkkIXAlAYgQZ2qbC2P8hiDpRh54aAw=="],
+
+    "@auth0/auth0-spa-js": ["@auth0/auth0-spa-js@2.19.2", "", { "dependencies": { "@auth0/auth0-auth-js": "1.6.0", "browser-tabs-lock": "1.3.0", "dpop": "2.1.1", "es-cookie": "1.3.2" } }, "sha512-NJOjPQZjZ8g2LXkBjNiYtf614WGVhwCg+q9L2MXcEQqey+ign9CG/wnl9OxYDz7XuItWecfYQLbiVTjIGNZ/Dw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -699,6 +706,8 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "browser-tabs-lock": ["browser-tabs-lock@1.3.0", "", { "dependencies": { "lodash": ">=4.17.21" } }, "sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw=="],
+
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
@@ -827,6 +836,8 @@
 
     "dotenv": ["dotenv@17.2.4", "", {}, "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw=="],
 
+    "dpop": ["dpop@2.1.1", "", {}, "sha512-J0Of2JTiM4h5si0tlbPQ/lkqfZ5wAEVkKYBhkwyyANnPJfWH4VsR5uIkZ+T+OSPIwDYUg1fbd5Mmodd25HjY1w=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
@@ -852,6 +863,8 @@
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
+
+    "es-cookie": ["es-cookie@1.3.2", "", {}, "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -1297,6 +1310,8 @@
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
 
+    "oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -1320,6 +1335,8 @@
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "openid-client": ["openid-client@6.8.4", "", { "dependencies": { "jose": "^6.2.2", "oauth4webapi": "^3.8.5" } }, "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -1868,6 +1885,8 @@
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "openid-client/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "unlink": "bun unlink"
   },
   "peerDependencies": {
+    "@auth0/auth0-react": "^2.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-router": "^6.0.0 || ^7.0.0",
@@ -53,6 +54,7 @@
     "sonner": "^2.0.7"
   },
   "devDependencies": {
+    "@auth0/auth0-react": "^2.16.2",
     "@eslint/js": "^9.30.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/src/auth/AuthGuard.tsx
+++ b/src/auth/AuthGuard.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { useAuth0 } from '@auth0/auth0-react'
+
+interface AuthGuardProps {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}
+
+// Custom component to wrap the protected route group for spesific page
+export function AuthGuard({ children, fallback = null }: AuthGuardProps) {
+  const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0()
+
+  React.useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      loginWithRedirect()
+    }
+  }, [isAuthenticated, isLoading, loginWithRedirect])
+
+  if (isLoading || !isAuthenticated) return <>{fallback}</>
+
+  return <>{children}</>
+}

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { Auth0Provider, useAuth0 } from '@auth0/auth0-react'
+import type { AppState } from '@auth0/auth0-react'
+import { TesseraProvider } from '../provider/AppProvider'
+import { AppPreloader } from '../components/app-preloader/app-preloader'
+
+export interface Auth0Config {
+  domain: string
+  clientId: string
+  audience: string
+  redirectUri?: string
+  organizationID?: string
+  prompt?: 'login' | 'consent' | 'select_account' | 'none'
+  onRedirectCallback?: (appState?: AppState) => void
+}
+
+interface AuthProviderProps {
+  children: React.ReactNode
+  auth0: Auth0Config
+  identiesApiUrl: string
+  onUnauthenticated?: () => void
+  requireAuth?: boolean
+  loadingFallback?: React.ReactNode
+}
+
+interface BridgeProps {
+  children: React.ReactNode
+  identiesApiUrl: string
+  audience: string
+  onUnauthenticated?: () => void
+  requireAuth: boolean
+  loadingFallback: React.ReactNode
+}
+
+function TesseraAuth0Bridge({
+  children,
+  identiesApiUrl,
+  audience,
+  onUnauthenticated,
+  requireAuth,
+  loadingFallback,
+}: BridgeProps) {
+  const { isAuthenticated, isLoading, getAccessTokenSilently, loginWithRedirect } = useAuth0()
+  const [token, setToken] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (isLoading) return
+    if (!isAuthenticated) {
+      if (onUnauthenticated) {
+        onUnauthenticated() // Custom redirect
+      } else if (requireAuth) {
+        loginWithRedirect() // Auto redirect to login page from auth0
+      }
+      return
+    }
+    getAccessTokenSilently({ authorizationParams: { audience } })
+      .then(setToken) // get shared token
+      .catch(() => {
+        if (requireAuth) {
+          loginWithRedirect()
+        }
+      })
+  }, [isAuthenticated, isLoading, audience, requireAuth, getAccessTokenSilently, loginWithRedirect])
+
+  // Display loading when waiting app getting token
+  if (isLoading) return <>{loadingFallback || <AppPreloader className="h-screen" />}</>
+
+  // Handle public page which don't need token
+  if (!token) return requireAuth ? null : <>{children}</>
+
+  return (
+    <TesseraProvider token={token} identiesApiUrl={identiesApiUrl}>
+      {children}
+    </TesseraProvider>
+  )
+}
+
+export function AuthProvider({
+  children,
+  auth0,
+  identiesApiUrl,
+  onUnauthenticated,
+  requireAuth = true,
+  loadingFallback = null,
+}: AuthProviderProps) {
+  const { domain, clientId, audience, redirectUri, prompt, onRedirectCallback, organizationID } =
+    auth0
+
+  return (
+    <Auth0Provider
+      domain={domain}
+      clientId={clientId}
+      onRedirectCallback={onRedirectCallback}
+      authorizationParams={{
+        redirect_uri: redirectUri ?? window.location.origin,
+        audience,
+        organization: organizationID,
+        ...(prompt && { prompt }),
+      }}>
+      <TesseraAuth0Bridge
+        identiesApiUrl={identiesApiUrl}
+        audience={audience}
+        requireAuth={requireAuth}
+        loadingFallback={loadingFallback}
+        onUnauthenticated={onUnauthenticated}>
+        {children}
+      </TesseraAuth0Bridge>
+    </Auth0Provider>
+  )
+}

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -1,0 +1,303 @@
+# Auth — tessera-ui
+
+Authentication integration built on top of [Auth0](https://auth0.com/). Provides `AuthProvider`, `AuthGuard`, and `useAuth` for all apps in the platform.
+
+---
+
+## How it works
+
+```
+AuthProvider
+  └── Auth0Provider        — handles login / logout / token lifecycle
+        └── TesseraAuth0Bridge  — silently fetches access token
+              └── TesseraProvider  — exposes user & applications via useApp()
+                    └── your app
+```
+
+`AuthProvider` is the single entry point. It replaces both `Auth0Provider` and `TesseraProvider` / `IdentiesProvider` — you do not need to use those directly.
+
+---
+
+## Installation
+
+`@auth0/auth0-react` is a peer dependency. Install it in your app:
+
+```sh
+bun add @auth0/auth0-react
+# or
+npm install @auth0/auth0-react
+```
+
+---
+
+## Environment variables
+
+Add these to your app's `.env`:
+
+```env
+VITE_AUTH0_DOMAIN=your-tenant.us.auth0.com
+VITE_AUTH0_CLIENT_ID=your_client_id
+VITE_AUTH0_AUDIENCE=https://your-api-audience
+VITE_IDENTIES_API_URL=https://api.example.com
+```
+
+---
+
+## Basic setup
+
+Wrap your app root with `AuthProvider`. All other providers (`ReactQueryProvider`, etc.) go inside as children.
+
+```tsx
+// main.tsx
+import { AuthProvider } from 'tessera-ui'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <AuthProvider
+    auth0={{
+      domain: import.meta.env.VITE_AUTH0_DOMAIN,
+      clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
+      audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+      redirectUri: window.location.origin,
+      prompt: 'select_account',
+    }}
+    identiesApiUrl={import.meta.env.VITE_IDENTIES_API_URL}>
+    <ReactQueryProvider>
+      <App />
+    </ReactQueryProvider>
+  </AuthProvider>
+)
+```
+
+Unauthenticated users are automatically redirected to Auth0 login.
+
+---
+
+## Migrating from Auth0Provider + IdentiesProvider
+
+**Before:**
+
+```tsx
+<Auth0Provider
+  domain={domain}
+  clientId={clientID}
+  onRedirectCallback={onRedirectCallback}
+  authorizationParams={{
+    redirect_uri: hostUrl,
+    audience: audience,
+    prompt: 'select_account',
+  }}>
+  <ReactQueryProvider>
+    <IdentiesProvider identiesApiUrl={identiesApiUrl}>
+      <PersistenceDataProvider>
+        <Outlet />
+      </PersistenceDataProvider>
+    </IdentiesProvider>
+  </ReactQueryProvider>
+</Auth0Provider>
+```
+
+**After:**
+
+```tsx
+import { AuthProvider } from 'tessera-ui'
+
+;<AuthProvider
+  auth0={{
+    domain,
+    clientId: clientID,
+    audience,
+    redirectUri: hostUrl,
+    prompt: 'select_account',
+    onRedirectCallback,
+  }}
+  identiesApiUrl={identiesApiUrl}>
+  <ReactQueryProvider>
+    <PersistenceDataProvider>
+      <Outlet />
+    </PersistenceDataProvider>
+  </ReactQueryProvider>
+</AuthProvider>
+```
+
+---
+
+## AuthProvider props
+
+| Prop                       | Type                                                 | Required | Default                  | Description                                                                                                                                                  |
+| -------------------------- | ---------------------------------------------------- | -------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `auth0.domain`             | `string`                                             | Yes      | —                        | Auth0 tenant domain                                                                                                                                          |
+| `auth0.clientId`           | `string`                                             | Yes      | —                        | Auth0 application client ID                                                                                                                                  |
+| `auth0.audience`           | `string`                                             | Yes      | —                        | API audience (used for access token scope)                                                                                                                   |
+| `auth0.redirectUri`        | `string`                                             | No       | `window.location.origin` | Redirect URL after login                                                                                                                                     |
+| `auth0.prompt`             | `'login' \| 'consent' \| 'select_account' \| 'none'` | No       | —                        | Auth0 prompt behaviour                                                                                                                                       |
+| `auth0.onRedirectCallback` | `(appState?) => void`                                | No       | —                        | Called after Auth0 redirects back to the app                                                                                                                 |
+| `identiesApiUrl`           | `string`                                             | Yes      | —                        | Base URL of the Identies API                                                                                                                                 |
+| `requireAuth`              | `boolean`                                            | No       | `true`                   | When `false`, public routes render freely — use `AuthGuard` to protect specific routes                                                                       |
+| `onUnauthenticated`        | `() => void`                                         | No       | `loginWithRedirect()`    | Custom handler when user is not authenticated. Fires regardless of `requireAuth`. When omitted and `requireAuth={true}`, falls back to `loginWithRedirect()` |
+
+---
+
+## Hooks
+
+### `useApp()`
+
+Access the authenticated user and their applications. Available anywhere inside `AuthProvider`.
+
+```tsx
+import { useApp } from 'tessera-ui'
+
+function Header() {
+  const { user, applications, isLoadingIdenties } = useApp()
+
+  if (isLoadingIdenties) return <Spinner />
+  return <span>{user?.email}</span>
+}
+```
+
+| Value               | Type                        | Description                                  |
+| ------------------- | --------------------------- | -------------------------------------------- |
+| `user`              | `User \| null`              | Authenticated user profile from Identies API |
+| `applications`      | `Application[]`             | Apps the user has access to                  |
+| `isLoadingIdenties` | `boolean`                   | Loading state for user fetch                 |
+| `isLoadingApps`     | `boolean`                   | Loading state for applications fetch         |
+| `token`             | `string \| null`            | Raw Auth0 access token                       |
+| `error`             | `ApiError \| null`          | Error from Identies API                      |
+| `updateUser`        | `(update) => Promise<void>` | Update the current user profile              |
+
+### `useAuth()`
+
+Access Auth0 state and actions.
+
+```tsx
+import { useAuth } from 'tessera-ui'
+
+function UserMenu() {
+  const { isAuthenticated, user, logout } = useAuth()
+
+  return <button onClick={() => logout()}>Sign out {user?.email}</button>
+}
+```
+
+| Value               | Type                    | Description                                    |
+| ------------------- | ----------------------- | ---------------------------------------------- |
+| `isAuthenticated`   | `boolean`               | Whether the user is logged in                  |
+| `isLoading`         | `boolean`               | Auth0 initialisation loading state             |
+| `user`              | `AuthUser \| undefined` | Auth0 user profile (email, name, picture, sub) |
+| `loginWithRedirect` | `() => void`            | Trigger Auth0 login                            |
+| `logout`            | `(options?) => void`    | Log out. Accepts optional `returnTo` URL       |
+| `getAccessToken`    | `() => Promise<string>` | Fetch the current access token silently        |
+
+---
+
+## AuthGuard
+
+Use `AuthGuard` to protect specific routes when you have a mix of public and private pages.
+
+```tsx
+import { AuthGuard } from 'tessera-ui'
+
+// Protect a single route
+;<Route
+  path="/dashboard"
+  element={
+    <AuthGuard fallback={<Spinner />}>
+      <Dashboard />
+    </AuthGuard>
+  }
+/>
+```
+
+| Prop       | Type        | Required | Description                                                |
+| ---------- | ----------- | -------- | ---------------------------------------------------------- |
+| `children` | `ReactNode` | Yes      | Content to render when authenticated                       |
+| `fallback` | `ReactNode` | No       | Shown while loading or unauthenticated. Defaults to `null` |
+
+---
+
+## Public and private routes
+
+By default `requireAuth={true}` — the entire app is protected and `AuthGuard` is not needed.
+
+If your app has a mix of public and private routes, set `requireAuth={false}` on `AuthProvider` and use `AuthGuard` to wrap the protected route group:
+
+```tsx
+// main.tsx
+<AuthProvider
+  auth0={{ domain, clientId, audience }}
+  identiesApiUrl={identiesApiUrl}
+  requireAuth={false}>
+  <Routes>
+    {/* Public — no auth required */}
+    <Route path="/login" element={<LoginPage />} />
+    <Route path="/about" element={<AboutPage />} />
+
+    {/* Protected — AuthGuard redirects unauthenticated users */}
+    <Route
+      element={
+        <AuthGuard fallback={<Spinner />}>
+          <Outlet />
+        </AuthGuard>
+      }>
+      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/settings" element={<Settings />} />
+    </Route>
+  </Routes>
+</AuthProvider>
+```
+
+**Behaviour summary:**
+
+|                      | `requireAuth={true}` (default) | `requireAuth={false}`                    |
+| -------------------- | ------------------------------ | ---------------------------------------- |
+| Unauthenticated user | Auto-redirected to login       | Public routes render freely              |
+| Authenticated user   | `useApp()` works everywhere    | `useApp()` works inside protected routes |
+| Use `AuthGuard`?     | Not needed                     | Yes — wrap protected route groups        |
+
+> `useApp()` returns empty defaults on public routes when the user is not authenticated. This is safe — no error is thrown.
+
+---
+
+## Custom unauthenticated redirect
+
+By default, unauthenticated users are sent straight to the Auth0 login page. Pass `onUnauthenticated` to override this — useful for redirecting to a custom login page or preserving the return path.
+
+```tsx
+const navigate = useNavigate()
+
+<AuthProvider
+  auth0={{ ... }}
+  identiesApiUrl={identiesApiUrl}
+  onUnauthenticated={() => navigate('/login')}
+>
+  ...
+</AuthProvider>
+```
+
+```tsx
+// Preserve the page the user was trying to reach
+<AuthProvider
+  auth0={{ ... }}
+  identiesApiUrl={identiesApiUrl}
+  onUnauthenticated={() =>
+    loginWithRedirect({ appState: { returnTo: window.location.pathname } })
+  }
+>
+  ...
+</AuthProvider>
+```
+
+---
+
+## When to use TesseraProvider directly
+
+`TesseraProvider` is the lower-level building block. Use it only when Auth0 is not involved — for example, when the token comes from a backend session or another auth provider.
+
+```tsx
+import { TesseraProvider } from 'tessera-ui'
+
+;<TesseraProvider token={tokenFromBackend} identiesApiUrl={apiUrl}>
+  <App />
+</TesseraProvider>
+```
+
+For all Auth0-based apps, use `AuthProvider` instead.

--- a/src/auth/auth.mdx
+++ b/src/auth/auth.mdx
@@ -1,0 +1,183 @@
+import { Meta } from '@storybook/blocks'
+import { StorybookTable } from '../components/misc/storybook-table/storybook-table.tsx'
+
+<Meta title="Auth/AuthProvider" />
+
+# AuthProvider
+
+Integrates [Auth0](https://auth0.com/) as the authentication provider for all Tessera apps. Wraps `Auth0Provider`, silently fetches an access token, and feeds it into `TesseraProvider` — giving every component in the tree access to both auth state and identities data.
+
+## How it works
+
+```
+AuthProvider
+  └── Auth0Provider        — handles login / logout / token lifecycle
+        └── TesseraAuth0Bridge  — silently fetches access token
+              └── TesseraProvider  — exposes user & applications via useApp()
+                    └── your app
+```
+
+## Installation
+
+`@auth0/auth0-react` is a peer dependency. Install it in your app:
+
+```sh
+bun add @auth0/auth0-react
+```
+
+## Basic setup
+
+```tsx
+import { AuthProvider } from 'tessera-ui'
+
+<AuthProvider
+  auth0={{
+    domain: import.meta.env.VITE_AUTH0_DOMAIN,
+    clientId: import.meta.env.VITE_AUTH0_CLIENT_ID,
+    audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+  }}
+  identiesApiUrl={import.meta.env.VITE_IDENTIES_API_URL}
+>
+  <App />
+</AuthProvider>
+```
+
+Unauthenticated users are automatically redirected to the Auth0 login page.
+
+## AuthProvider props
+
+<StorybookTable
+  rows={[
+    { name: 'auth0.domain', required: true, type: 'string', description: 'Auth0 tenant domain' },
+    { name: 'auth0.clientId', required: true, type: 'string', description: 'Auth0 application client ID' },
+    { name: 'auth0.audience', required: true, type: 'string', description: 'API audience used for access token scope' },
+    { name: 'auth0.redirectUri', required: false, type: 'string', default: 'window.location.origin', description: 'Redirect URL after login' },
+    { name: 'auth0.prompt', required: false, type: "'login' | 'consent' | 'select_account' | 'none'", description: 'Auth0 prompt behaviour' },
+    { name: 'auth0.organizationID', required: false, type: 'string', description: 'Auth0 organization ID for org-level login' },
+    { name: 'auth0.onRedirectCallback', required: false, type: '(appState?) => void', description: 'Called after Auth0 redirects back to the app' },
+    { name: 'identiesApiUrl', required: true, type: 'string', description: 'Base URL of the Identies API' },
+    { name: 'requireAuth', required: false, type: 'boolean', default: 'true', description: 'When false, public routes render freely — use AuthGuard to protect specific routes' },
+    { name: 'loadingFallback', required: false, type: 'ReactNode', default: 'null', description: 'Rendered while Auth0 is initialising' },
+    { name: 'onUnauthenticated', required: false, type: '() => void', default: 'loginWithRedirect()', description: 'Custom handler when the user is not authenticated. Fires regardless of requireAuth. Falls back to loginWithRedirect() when omitted and requireAuth is true' },
+  ]}
+/>
+
+---
+
+# AuthGuard
+
+Protects individual routes by redirecting unauthenticated users. Use this when `requireAuth={false}` and you need to protect specific route groups.
+
+```tsx
+import { AuthGuard } from 'tessera-ui'
+
+<Route element={<AuthGuard fallback={<Spinner />}><Outlet /></AuthGuard>}>
+  <Route path="/dashboard" element={<Dashboard />} />
+</Route>
+```
+
+<StorybookTable
+  rows={[
+    { name: 'children', required: true, type: 'ReactNode', description: 'Rendered when the user is authenticated' },
+    { name: 'fallback', required: false, type: 'ReactNode', default: 'null', description: 'Rendered while loading or when unauthenticated' },
+  ]}
+/>
+
+---
+
+# Hooks
+
+## useApp()
+
+Access the authenticated user and their applications. Available inside `AuthProvider`.
+
+```tsx
+import { useApp } from 'tessera-ui'
+
+const { user, applications, isLoadingIdenties } = useApp()
+```
+
+<StorybookTable
+  rows={[
+    { name: 'user', required: false, type: 'User | null', description: 'Authenticated user profile from the Identies API' },
+    { name: 'applications', required: false, type: 'Application[]', description: 'Apps the user has access to' },
+    { name: 'isLoadingIdenties', required: false, type: 'boolean', description: 'Loading state for user fetch' },
+    { name: 'isLoadingApps', required: false, type: 'boolean', description: 'Loading state for applications fetch' },
+    { name: 'token', required: false, type: 'string | null', description: 'Raw Auth0 access token' },
+    { name: 'error', required: false, type: 'ApiError | null', description: 'Error from the Identies API' },
+    { name: 'updateUser', required: false, type: '(update: UserUpdate) => Promise<void>', description: 'Update the current user profile' },
+  ]}
+/>
+
+## useAuth()
+
+Access Auth0 state and actions.
+
+```tsx
+import { useAuth } from 'tessera-ui'
+
+const { isAuthenticated, user, logout, getAccessToken } = useAuth()
+```
+
+<StorybookTable
+  rows={[
+    { name: 'isAuthenticated', required: false, type: 'boolean', description: 'Whether the user is logged in' },
+    { name: 'isLoading', required: false, type: 'boolean', description: 'Auth0 initialisation loading state' },
+    { name: 'user', required: false, type: 'AuthUser | undefined', description: 'Auth0 user profile (email, name, picture, sub)' },
+    { name: 'loginWithRedirect', required: false, type: '() => void', description: 'Trigger Auth0 login' },
+    { name: 'logout', required: false, type: '(options?: { returnTo?: string }) => void', description: 'Log out and redirect. Defaults to window.location.origin' },
+    { name: 'getAccessToken', required: false, type: '() => Promise<string>', description: 'Fetch the current access token silently' },
+  ]}
+/>
+
+---
+
+# Public and private routes
+
+By default the entire app is protected (`requireAuth={true}`). For apps with mixed public/private routes:
+
+```tsx
+<AuthProvider
+  auth0={{ ... }}
+  identiesApiUrl={identiesApiUrl}
+  requireAuth={false}
+>
+  <Routes>
+    <Route path="/login" element={<LoginPage />} />
+    <Route path="/about" element={<AboutPage />} />
+
+    <Route element={<AuthGuard fallback={<Spinner />}><Outlet /></AuthGuard>}>
+      <Route path="/dashboard" element={<Dashboard />} />
+    </Route>
+  </Routes>
+</AuthProvider>
+```
+
+---
+
+# Using in Storybook
+
+Components that use `useApp()` or `useAuth()` need a mock provider in stories. Import `withAuth` from `auth.mock`:
+
+```tsx
+import { withAuth } from '@/auth/auth.mock'
+
+const meta: Meta<typeof MyComponent> = {
+  title: 'MyComponent',
+  component: MyComponent,
+  decorators: [withAuth()],
+}
+```
+
+Override specific context values for a story:
+
+```tsx
+export const AsAdmin: Story = {
+  decorators: [
+    withAuth({
+      user: { ...mockUser, first_name: 'Admin', verified: true },
+      applications: [{ id: '1', name: 'App One' }],
+    }),
+  ],
+}
+```

--- a/src/auth/auth.mock.tsx
+++ b/src/auth/auth.mock.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { Auth0Context } from '@auth0/auth0-react'
+import type { Auth0ContextInterface } from '@auth0/auth0-react'
+import { TesseraUIContext } from '../provider/AppProvider'
+import type { ITesseraUIContextProps } from '../provider/AppProvider'
+import type { User } from '../types/user'
+
+export const mockUser: User = {
+  id: 'mock-user-id',
+  email: 'demo@tessera.io',
+  username: 'demo',
+  first_name: 'Demo',
+  last_name: 'User',
+  verified: true,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+const mockAuth0Context = {
+  isAuthenticated: true,
+  isLoading: false,
+  user: {
+    email: mockUser.email,
+    name: `${mockUser.first_name} ${mockUser.last_name}`,
+    sub: 'auth0|mock-user-id',
+  },
+  loginWithRedirect: async () => {},
+  logout: async () => {},
+  getAccessTokenSilently: async () => 'mock-access-token',
+  getIdTokenClaims: async () => undefined,
+  handleRedirectCallback: async () => ({ appState: undefined }),
+} as unknown as Auth0ContextInterface
+
+const mockTesseraUIContext: ITesseraUIContextProps = {
+  token: 'mock-access-token',
+  user: mockUser,
+  isLoadingIdenties: false,
+  isLoadingApps: false,
+  error: null,
+  applications: [],
+  updateUser: async () => {},
+}
+
+interface MockAuthProviderProps {
+  children: React.ReactNode
+  overrides?: Partial<ITesseraUIContextProps>
+}
+
+export function MockAuthProvider({ children, overrides }: MockAuthProviderProps) {
+  return (
+    <Auth0Context.Provider value={mockAuth0Context}>
+      <TesseraUIContext.Provider value={{ ...mockTesseraUIContext, ...overrides }}>
+        {children}
+      </TesseraUIContext.Provider>
+    </Auth0Context.Provider>
+  )
+}
+
+export function withAuth(overrides?: Partial<ITesseraUIContextProps>) {
+  // eslint-disable-next-line react/display-name
+  return (Story: React.ComponentType) => (
+    <MockAuthProvider overrides={overrides}>
+      <Story />
+    </MockAuthProvider>
+  )
+}

--- a/src/auth/auth.stories.tsx
+++ b/src/auth/auth.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta } from '@storybook/react-vite'
+import AuthDocs from './auth.mdx'
+
+const meta: Meta = {
+  title: 'Auth/AuthProvider',
+  parameters: {
+    docs: {
+      page: AuthDocs,
+    },
+  },
+}
+
+export default meta

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,5 @@
+export { AuthProvider } from './AuthProvider'
+export type { Auth0Config } from './AuthProvider'
+export { AuthGuard } from './AuthGuard'
+export { useAuth } from './useAuth'
+export type { AuthState, AuthUser } from './useAuth'

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -1,0 +1,33 @@
+import { useAuth0 } from '@auth0/auth0-react'
+
+export interface AuthUser {
+  email?: string
+  name?: string
+  picture?: string
+  sub?: string
+  [key: string]: unknown
+}
+
+export interface AuthState {
+  isAuthenticated: boolean
+  isLoading: boolean
+  user: AuthUser | undefined
+  loginWithRedirect: () => void
+  logout: (options?: { returnTo?: string }) => void
+  getAccessToken: () => Promise<string>
+}
+
+export function useAuth(): AuthState {
+  const { isAuthenticated, isLoading, user, loginWithRedirect, logout, getAccessTokenSilently } =
+    useAuth0()
+
+  return {
+    isAuthenticated,
+    isLoading,
+    user,
+    loginWithRedirect: () => loginWithRedirect(),
+    logout: (options) =>
+      logout({ logoutParams: { returnTo: options?.returnTo ?? window.location.origin } }),
+    getAccessToken: () => getAccessTokenSilently(),
+  }
+}

--- a/src/components/app-preloader/app-preloader.mdx
+++ b/src/components/app-preloader/app-preloader.mdx
@@ -1,0 +1,47 @@
+import { Meta } from '@storybook/blocks'
+import { StorybookTable } from '../misc/storybook-table/storybook-table.tsx'
+
+<Meta title="Feedback/AppPreloader" />
+
+# AppPreloader
+
+The `AppPreloader` component displays a full-area loading screen while the application is initializing. It centers a spinner graphic within its container and is typically rendered at the root level before the main UI is ready.
+
+## Features
+
+- **Full-area coverage**: Stretches to fill its parent container (height and width 100%)
+- **Centered content**: Uses CSS grid to center the loading indicator
+- **Customizable**: Accepts an optional `className` to override or extend styles
+- **Dark Mode Support**: Inherits `bg-background` which adapts to the active theme
+
+## Usage
+
+```tsx
+import { AppPreloader } from 'tessera-ui/components/app-preloader'
+
+function App() {
+  if (!isReady) {
+    return <AppPreloader />
+  }
+
+  return <MainLayout />
+}
+```
+
+## Props
+
+<StorybookTable
+  rows={[
+    {
+      name: 'className',
+      required: false,
+      type: 'string',
+      description: 'Additional CSS classes to apply to the root element',
+    },
+  ]}
+/>
+
+## Notes
+
+- The component relies on CSS defined under the `.app-preloader` and `.app-preloader-inner` class names for its animation — ensure your global stylesheet includes these rules
+- Wrap the component in a `div` with an explicit height if the parent does not have one, otherwise the preloader will collapse to zero height

--- a/src/components/app-preloader/app-preloader.stories.tsx
+++ b/src/components/app-preloader/app-preloader.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { AppPreloader } from './app-preloader'
+import AppPreloaderDocs from './app-preloader.mdx'
+
+const meta: Meta<typeof AppPreloader> = {
+  title: 'Feedback/AppPreloader',
+  component: AppPreloader,
+  parameters: {
+    docs: {
+      page: AppPreloaderDocs,
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithCustomClass: Story = {
+  args: {
+    className: 'h-64 w-64 border border-dashed rounded-lg',
+  },
+}
+
+export const FullScreen: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100vh', width: '100vw' }}>
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/components/app-preloader/app-preloader.tsx
+++ b/src/components/app-preloader/app-preloader.tsx
@@ -1,0 +1,14 @@
+import { cn } from '../../utils/misc'
+import '../../styles/spinner.css'
+
+export function AppPreloader({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        'app-preloader bg-background grid h-full w-full place-content-center',
+        className
+      )}>
+      <div className="app-preloader-inner relative inline-block size-48"></div>
+    </div>
+  )
+}

--- a/src/components/applications/application.stories.tsx
+++ b/src/components/applications/application.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import type React from 'react'
 import { withRouter } from 'storybook-addon-remix-react-router'
 import { Applications } from './application'
-import { CoreUIContext, type ICoreUIContextProps } from '../../provider/AppProvider'
+import { TesseraUIContext, type ITesseraUIContextProps } from '../../provider/AppProvider'
 import type { Application } from '../../types/application'
 import ApplicationDocs from './application.mdx'
 
@@ -90,7 +90,7 @@ const applicationsMock: Application[] = [
   },
 ]
 
-const buildContext = (overrides?: Partial<ICoreUIContextProps>): ICoreUIContextProps => ({
+const buildContext = (overrides?: Partial<ITesseraUIContextProps>): ITesseraUIContextProps => ({
   token: 'storybook-token',
   user: null,
   isLoadingIdenties: false,
@@ -102,12 +102,12 @@ const buildContext = (overrides?: Partial<ICoreUIContextProps>): ICoreUIContextP
 })
 
 const withAppContext =
-  (contextValue: ICoreUIContextProps) =>
+  (contextValue: ITesseraUIContextProps) =>
   // eslint-disable-next-line react/display-name
   (Story: React.ComponentType): React.JSX.Element => (
-    <CoreUIContext.Provider value={contextValue}>
+    <TesseraUIContext.Provider value={contextValue}>
       <Story />
-    </CoreUIContext.Provider>
+    </TesseraUIContext.Provider>
   )
 
 const meta: Meta<typeof Applications> = {

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,12 +1,8 @@
 import { cn } from '../../utils/misc'
 
-function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+function Skeleton({ className }: React.ComponentProps<'div'>) {
   return (
-    <div
-      data-slot="skeleton"
-      className={cn('bg-accent animate-pulse rounded-md', className)}
-      {...props}
-    />
+    <div data-slot="skeleton" className={cn('bg-accent animate-pulse rounded-md', className)}></div>
   )
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,10 @@ import '../src/styles/layout.css'
 // Provider
 export { TesseraProvider, useApp } from './provider/AppProvider'
 
+// Auth
+export { AuthProvider, AuthGuard, useAuth } from './auth'
+export type { Auth0Config, AuthState, AuthUser } from './auth'
+
 // Component
 export { ProfileMenu } from './components/misc/ProfileMenu/ProfileMenu'
 export { FormField, FormSelect, FormWrapper } from './components/misc/Form'

--- a/src/provider/AppProvider.tsx
+++ b/src/provider/AppProvider.tsx
@@ -3,7 +3,7 @@ import type { ApiError, User, UserUpdate } from '../types/user'
 import { useIdenties } from '../hooks/useIdenties'
 import type { Application } from '../types/application'
 
-export interface ICoreUIContextProps {
+export interface ITesseraUIContextProps {
   user: User | null
   isLoadingIdenties: boolean
   error: ApiError | null
@@ -14,7 +14,7 @@ export interface ICoreUIContextProps {
   updateUser: (userUpdate: UserUpdate) => Promise<void>
 }
 
-export const CoreUIContext = React.createContext<ICoreUIContextProps>({
+export const TesseraUIContext = React.createContext<ITesseraUIContextProps>({
   token: null,
   user: null,
   isLoadingIdenties: true,
@@ -49,11 +49,11 @@ export function TesseraProvider({ children, token, identiesApiUrl }: IProviderPr
     [user, token, loading]
   )
 
-  return <CoreUIContext.Provider value={contextPayload}>{children}</CoreUIContext.Provider>
+  return <TesseraUIContext.Provider value={contextPayload}>{children}</TesseraUIContext.Provider>
 }
 
-export const useApp = (): ICoreUIContextProps => {
-  const context = React.useContext(CoreUIContext)
+export const useApp = (): ITesseraUIContextProps => {
+  const context = React.useContext(TesseraUIContext)
 
   if (!context) {
     throw new Error('useApp must be used within an IdentiesProvider')

--- a/src/styles/spinner.css
+++ b/src/styles/spinner.css
@@ -3,7 +3,7 @@
 /* app-preloader */
 .app-preloader .app-preloader-inner::after,
 .app-preloader .app-preloader-inner::before {
-  @apply dark:bg-navy-300/50 absolute top-0 left-0 h-full w-full rounded-full bg-slate-300/[.25] content-[''];
+  @apply dark:bg-[#697a9b] absolute top-0 left-0 h-full w-full rounded-full bg-slate-300/[.25] content-[''];
   animation: spinner-grow 3s cubic-bezier(0.55, 0.15, 0.45, 0.85) infinite;
 }
 


### PR DESCRIPTION
## Summary

- New `src/auth/` module — `AuthProvider`, `AuthGuard`, `useAuth` hook, and a Storybook mock decorator (`withAuth`)
- `AuthProvider` replaces the manual `Auth0Provider + IdentiesProvider` stack. It silently fetches an access token and feeds it into `TesseraProvider`, giving the whole tree access to auth state and identities data via `useApp()` and `useAuth()`
- `AuthGuard` protects individual route groups when `requireAuth={false}` is used for mixed public/private apps
- `useAuth()` exposes `isAuthenticated`, `user`, `logout`, `loginWithRedirect`, and `getAccessToken`
- `AppPreloader` used as the default loading fallback during Auth0 initialisation; customisable via `loadingFallback` prop
- Storybook — MDX docs page under `Auth / AuthProvider` and `withAuth` mock decorator for component stories that depend on auth context
- `package.json` — added `@auth0/auth0-react ^2.0.0` as peer dependency