### PR TITLE
Forward sidebar divider props through MainLayout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,12 @@
     "": {
       "name": "tessera-ui",
       "dependencies": {
-        "@auth0/auth0-react": "^2.16.2",
         "axios": "^1.10.0",
         "cmdk": "^1.1.1",
         "radix-ui": "^1.4.3",
       },
       "devDependencies": {
+        "@auth0/auth0-react": "^2.16.2",
         "@eslint/js": "^9.30.1",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -62,6 +62,7 @@
         "vite-tsconfig-paths": "^6.0.0",
       },
       "peerDependencies": {
+        "@auth0/auth0-react": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",

--- a/src/components/layouts/main/main-layout.stories.tsx
+++ b/src/components/layouts/main/main-layout.stories.tsx
@@ -80,6 +80,7 @@ const defaultMenuItems: MainItemProps[] = [
     path: '#',
     icon: Users,
     disabled: true,
+    divider: true,
   },
   {
     title: 'Settings',

--- a/src/components/layouts/main/sidebar/sidebar-menu.tsx
+++ b/src/components/layouts/main/sidebar/sidebar-menu.tsx
@@ -57,6 +57,9 @@ export function SidebarMenu({ menuItems }: { menuItems: MainItemProps[] }): Reac
                   <span>{item.title}</span>
                 </Link>
               </SidebarMenuButton>
+              {item.divider && (
+                <hr className="my-2 border-t border-slate-200 dark:border-slate-700" />
+              )}
             </SidebarMenuItem>
           ))}
         </div>

--- a/src/components/layouts/main/sidebar/sidebar-panel.stories.tsx
+++ b/src/components/layouts/main/sidebar/sidebar-panel.stories.tsx
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof meta>
 
 const defaultMenuItems: MainItemProps[] = [
   { title: 'Roles', path: '/roles', icon: KeyRound, disabled: true },
-  { title: 'Users', path: '/users', icon: Users, disabled: true },
+  { title: 'Users', path: '/users', icon: Users, disabled: true, divider: true },
   { title: 'Settings', path: '/settings', icon: Settings, disabled: true },
 ]
 

--- a/src/types/mdx.d.ts
+++ b/src/types/mdx.d.ts
@@ -1,0 +1,5 @@
+declare module '*.mdx' {
+  import type { ComponentType } from 'react'
+  const MDXComponent: ComponentType<Record<string, unknown>>
+  export default MDXComponent
+}


### PR DESCRIPTION
## Summary
Fixes divider props being not impelemented correctly when ```Layout.Main``` is rendered by forwarding them through instead of relying on MainLayout's defaults.

## Root Cause
The sidebar that used in ```Layout.Main```  doesnt use the props there for the divider didnt got rendered

## Changes
- Implement the divider based on the sidebarnav
- Resolve mdx importing isue

## Testing
- [x] Verified divider renders correctly when passed via MainLayout
- [x] Verified existing Sidebar standalone usage (Storybook) still works
- [x] Checked no visual regression in default (no-divider) case

## Related
Closes #79 