### PR TITLE
FIxes responsive layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 *storybook.log
 storybook-static
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`tessera-ui` is TesseraHQ's private, shared React component library — not an app.
+It's distributed to consumer apps via `bun link` or a git dependency
+(`bun install git+https://github.com/tesserahq/tessera-ui.git`), imported under the
+`tessera-ui` path alias. There is no consumer app in this repo; changes here are
+verified through Storybook.
+
+## Commands
+
+```bash
+bun install          # install deps
+bun storybook        # Storybook dev server on :6006 — primary way to exercise components
+bun run dev           # Vite dev server
+bun run build         # tsc -b && vite build — library build (entry: src/main.ts)
+bun run typecheck     # tsc -b
+bun run lint          # eslint src/**/*.{ts,tsx}
+bun run lint:fix
+bun run format        # prettier --write
+bun run format:check
+bun run check         # format + lint + typecheck, run this before considering work done
+bun run build-storybook
+```
+
+There is no test runner configured in this repo (no unit/integration test script) —
+verification happens by running Storybook and clicking through the affected story.
+
+## Architecture
+
+### Public API surface (barrel exports)
+
+Everything consumers import flows through `src/main.ts`, which re-exports from:
+- `provider/AppProvider` — `TesseraProvider`, `useApp`
+- `auth` — `AuthProvider`, `AuthGuard`, `useAuth`
+- `components/misc/ProfileMenu`, `components/misc/Form`
+- `components` (barrel of `components/index.ts`, itself re-exporting `layouts`,
+  `app-menu`, `datetime`, `new-button`, `empty-content`, `toast`, `pagination`,
+  `combo-box`, `resource-id`)
+
+`package.json` also exposes narrower subpath exports (`tessera-ui/layouts`,
+`tessera-ui/components`, `tessera-ui/components/delete-confirmation`) mapped
+directly to their `index.ts`/component file. When adding a new public component,
+wire it into the relevant barrel file, not just its own folder.
+
+`src/components/layouts` uses a compound-component export pattern — `Layout` is
+assembled in `layouts/index.ts` as `Object.assign(Layout, { Main, Header, Detail,
+DetailHeader, DetailSidenav, DetailContent })`, so `Layout.Main`, `Layout.Header`,
+etc. are the real public names, not the underlying `MainLayout`/`Header` component
+names.
+
+### Auth and app data flow
+
+- `AuthProvider` (`src/auth/AuthProvider.tsx`) wraps Auth0 (`@auth0/auth0-react`)
+  and bridges it to this library's own context: it waits for Auth0 to finish
+  loading, resolves an access token via `getAccessTokenSilently`, and only then
+  mounts `TesseraProvider` around `children`. If there's no token and
+  `requireAuth` is false, `children` render *without* `TesseraProvider` — so
+  anything reading `useApp()` in that path must tolerate/handle that.
+- `TesseraProvider` (`src/provider/AppProvider.tsx`) calls `useIdenties`
+  (`src/hooks/useIdenties.ts`), which fetches the current user and applications
+  from `createIdentiesClient` (`src/api/client.ts`, an Axios wrapper) and exposes
+  `user`, `isLoadingIdenties`, `error`, `applications`, `isLoadingApps`,
+  `updateUser` via `useApp()`.
+- **Provider placement matters**: any component that calls `useApp()` must be
+  rendered under `TesseraProvider` in the actual React tree — not just visually
+  nested via CSS (e.g. `position: fixed`). Since `Layout.Header` and `Layout.Main`
+  are composed as siblings-in-JSX-but-parent/child-in-render by consumer apps
+  (`Layout.Header` is typically passed as a child of `Layout.Main`, which wraps
+  its `children` in its own `SidebarProvider`), always check where a new
+  `useApp()`/`useSidebar()` consumer sits in the actual component tree, not just
+  where it appears visually in the header/layout.
+- Storybook mocks: `src/auth/auth.mock.tsx` provides `MockAuthProvider`/`withAuth`
+  (wraps both `Auth0Context.Provider` and `TesseraUIContext.Provider` with fixed
+  mock data) for stories that need a populated user/app context without hitting
+  the real API. Stories that just need *a* provider (without caring about the
+  data) instead mount the real `TesseraProvider` directly with
+  `identiesApiUrl=""` `token=""` — see `header.stories.tsx`. Any story rendering
+  a component that calls `useApp()` needs one of these two, or it will throw.
+
+### Sidebar / mobile layout
+
+`src/components/ui/sidebar.tsx` is a shadcn-style sidebar primitive
+(`SidebarProvider`, `Sidebar`, `SidebarTrigger`, `SidebarRail`, `SidebarInset`,
+etc.) with its own mobile/desktop branching: below the `768px` breakpoint
+(`src/hooks/use-mobile.ts`, `useIsMobile()`) it renders as a `Sheet` overlay
+controlled by `openMobile`/`setOpenMobile`; at `md:` and above it renders as a
+persistent flex column. `src/components/layouts/main/sidebar/sidebar-panel.tsx`
+and `main-layout.tsx` are the concrete usage of this primitive for the app's main
+nav.
+
+This project's Tailwind theme (`src/index.css`, Tailwind v4 `@theme` block) only
+defines `--color-sidebar-background` (not the shadcn-standard bare
+`--color-sidebar`) plus `sidebar-border`/`sidebar-accent`/`sidebar-foreground`/etc.
+When touching `ui/sidebar.tsx`, use `bg-sidebar-background`, not `bg-sidebar` —
+the latter silently resolves to nothing (transparent) since it isn't a defined
+token in this theme.
+
+### Styling conventions
+
+- Tailwind v4, theme tokens defined in `src/index.css` under `@theme` (not a
+  `tailwind.config.ts` — this project uses CSS-first Tailwind config).
+- `cn()` (`src/utils/misc.ts`, `clsx` + `tailwind-merge`) is the standard
+  className-merge helper used throughout — prefer it over string concatenation
+  for any conditional/overridable className.
+- kebab-case filenames; Prettier is configured with `prettier-plugin-tailwindcss`
+  (auto-sorts Tailwind classes) and `@trivago/prettier-plugin-sort-imports`
+  (auto-sorts imports) — don't hand-order either, formatting will reorder them.
+- No semicolons, single quotes, 100-char print width (`prettier.config.mjs`).
+
+### Known documentation drift
+
+Several `.md`/`.stories.tsx`/docstring examples in this repo (e.g.
+`src/docs/coreui-provider.md`, the `MainLayout` docstring, parts of
+`src/components/layouts/README.md`) describe older prop APIs (like a `header`
+prop on `MainLayout`) that no longer match the current implementation. Don't
+trust doc comments or `.md` files over the actual component source/props when
+they conflict — verify against the real `interface`/`Props` type.

--- a/src/components/layouts/detail/detail-content.tsx
+++ b/src/components/layouts/detail/detail-content.tsx
@@ -7,5 +7,5 @@ interface Props {
 }
 
 export function DetailContent({ children, className }: Props) {
-  return <div className={cn('flex-1 p-3 h-auto ml-56', className)}>{children}</div>
+  return <div className={cn('flex-1 p-3 h-auto ml-14 md:ml-56', className)}>{children}</div>
 }

--- a/src/components/layouts/detail/detail-sidenav.tsx
+++ b/src/components/layouts/detail/detail-sidenav.tsx
@@ -23,8 +23,9 @@ export function DetailSidenav({ menuItems, className }: DetailSidenavProps): Rea
 
   const itemClassName = (active: boolean) => {
     return cn(
-      `hover:bg-primary/20 w-full text-sm flex p-2 mb-1 items-center justify-start gap-2
-        overflow-hidden rounded-md cursor-pointer hover:text-primary dark:hover:text-primary-foreground`,
+      `hover:bg-primary/20 w-full text-sm flex p-1.5 md:p-2 mb-1 items-center justify-center md:justify-start
+        gap-2 overflow-hidden rounded-md cursor-pointer hover:text-primary
+        dark:hover:text-primary-foreground`,
       active &&
         ' text-primary dark:text-primary-foreground bg-primary/10 border border-primary font-medium'
     )
@@ -33,7 +34,7 @@ export function DetailSidenav({ menuItems, className }: DetailSidenavProps): Rea
   return (
     <div
       className={cn(
-        'w-56 dark:bg-sidebar-background p-3 fixed h-full border-r bg-white overflow-y-auto',
+        'w-14 md:w-56 dark:bg-sidebar-background p-3 fixed h-full border-r bg-white overflow-y-auto',
         className
       )}>
       <Accordion
@@ -48,9 +49,12 @@ export function DetailSidenav({ menuItems, className }: DetailSidenavProps): Rea
               <AccordionItem value={item.path} className="border-none">
                 <AccordionTrigger
                   disabled={item.disabled}
-                  className={itemClassName(isMenuActive(item.path) || hasActiveChild(item))}>
+                  className={cn(
+                    itemClassName(isMenuActive(item.path) || hasActiveChild(item)),
+                    '[&_.accordion-chevron]:hidden md:[&_.accordion-chevron]:block'
+                  )}>
                   <item.icon size={18} />
-                  <span className="flex-1 text-left">{item.title}</span>
+                  <span className="flex-1 text-left hidden md:inline">{item.title}</span>
                 </AccordionTrigger>
                 <AccordionContent className="pb-0">
                   <div className="pl-2 space-y-1">
@@ -60,7 +64,7 @@ export function DetailSidenav({ menuItems, className }: DetailSidenavProps): Rea
                         to={child.disabled ? '#' : child.path}
                         className={itemClassName(isMenuActive(child.path))}>
                         <item.icon size={18} />
-                        {child.title}
+                        <span className="hidden md:inline">{child.title}</span>
                       </Link>
                     ))}
                   </div>
@@ -71,7 +75,7 @@ export function DetailSidenav({ menuItems, className }: DetailSidenavProps): Rea
                 to={item.disabled ? '#' : item.path}
                 className={itemClassName(isMenuActive(item.path))}>
                 <item.icon size={18} />
-                {item.title}
+                <span className="hidden md:inline">{item.title}</span>
               </Link>
             )}
 

--- a/src/components/layouts/main/header/header.tsx
+++ b/src/components/layouts/main/header/header.tsx
@@ -4,6 +4,7 @@ import { ProfileMenu, useApp } from '../../../../main'
 import { Applications } from '../../../applications/application'
 import { Avatar, AvatarFallback, AvatarImage } from '../../../ui/avatar'
 import { Separator } from '../../../ui/separator'
+import { SidebarTrigger } from '../../../ui/sidebar'
 
 interface IProps {
   title: string
@@ -42,7 +43,7 @@ export function Header({
         justify-between gap-2 top-0 backdrop-blur-md transition-[width,height] ease-linear pe-5
         shadow-2xs ps-2">
       {/* Left Content */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1 md:gap-2">
         <Applications currentApp={title} />
         <Link to="/" className="space-x-2">
           <div className="flex items-center gap-2 lg:ml-0">
@@ -69,8 +70,9 @@ export function Header({
       {contentCenter && <div className="flex-1">{contentCenter}</div>}
 
       {/* Right Content */}
-      <div className="pe-4 flex items-center gap-2">
+      <div className="md:pe-4 flex items-center gap-2">
         {contentRight && <div>{contentRight}</div>}
+        <SidebarTrigger className="md:hidden" />
         <ProfileMenu
           isStorybook={isStorybook}
           selectedTheme={selectedTheme}

--- a/src/components/layouts/main/main-layout.stories.tsx
+++ b/src/components/layouts/main/main-layout.stories.tsx
@@ -216,8 +216,8 @@ export const HomePage: Story = {
   },
   render: ({ collapseSidebar }) => (
     <MemoryRouter initialEntries={['/roles']}>
-      <MockHeader />
       <AutoCollapseMainLayout menuItems={defaultMenuItems} collapseSidebar={collapseSidebar}>
+        <MockHeader />
         <Routes>
           <Route path="/roles" element={<RolesListPage />} />
           <Route path="/roles/:id/overview" element={<RoleDetailPage />} />
@@ -244,8 +244,8 @@ export const DetailPage: Story = {
   },
   render: () => (
     <MemoryRouter initialEntries={['/roles']}>
-      <MockHeader />
       <AutoCollapseMainLayout menuItems={defaultMenuItems} collapseSidebar={true}>
+        <MockHeader />
         <Routes>
           <Route
             path="/roles"

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -171,7 +171,8 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className="bg-sidebar-background text-sidebar-foreground w-(--sidebar-width) p-0
+            [&>button]:hidden"
           style={
             {
               '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
@@ -294,7 +295,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        'bg-background relative flex w-full flex-1 flex-col',
+        'bg-background relative flex w-full flex-1 flex-col min-w-0',
         `md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0
         md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm
         md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2`,

--- a/src/provider/AppProvider.tsx
+++ b/src/provider/AppProvider.tsx
@@ -56,7 +56,7 @@ export const useApp = (): ITesseraUIContextProps => {
   const context = React.useContext(TesseraUIContext)
 
   if (!context) {
-    throw new Error('useApp must be used within an IdentiesProvider')
+    throw new Error('useApp must be used within a TesseraProvider')
   }
 
   return context


### PR DESCRIPTION
## Summary

- Add SidebarTrigger to Header, left of Applications, visible only on mobile
- Fix mobile Sheet using undefined bg-sidebar token instead of bg-sidebar-background
- Make DetailSidenav icon-only and narrower on mobile, with matching DetailContent margin
- Nest MockHeader inside MainLayout in stories to match real provider composition